### PR TITLE
Version Agnostic Updating

### DIFF
--- a/DeployPaycoinNode.sh
+++ b/DeployPaycoinNode.sh
@@ -37,5 +37,17 @@ rm -f -r linux64.zip
 rm -f -r paycoin-qt
 echo "### Scheduling Cron Job to run Paycoin Core on boot"
 (crontab -l ; echo "@reboot ~/./paycoind")| crontab -
-echo "### System will now reboot"
-reboot
+
+echo "### We recommend a system reboot to finish installation"
+read -p "### Would you like to reboot your system? " -n 1 -r
+echo    # Create new Line
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    # Reboot The System
+    echo "### System will reboot in 5 seconds"
+    sleep 5
+    reboot
+else
+    echo "### Please reboot your system for these changes to take effect"
+fi
+

--- a/DeployPaycoinNode.sh
+++ b/DeployPaycoinNode.sh
@@ -9,7 +9,7 @@ echo "### Update Ubuntu"
 sudo apt-get update -y
 sudo apt-get upgrade -y
 sudo apt-get dist-upgrade -y
-sudo apt-get install software-properties-common python-software-properties unzip ufw curl wget -y
+sudo apt-get install software-properties-common python-software-properties unzip ufw curl wget sed -y
 echo "### Allow ports 22, 8998 and enable The Uncomplicated Firewall"
 sudo ufw allow 22/tcp
 sudo ufw allow 8998/tcp

--- a/DeployPaycoinNode.sh
+++ b/DeployPaycoinNode.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+version=$(curl -s https://api.github.com/repos/PaycoinFoundation/Paycoin/releases/latest | grep 'tag_' | cut -d\" -f4)
+latest=$(curl -s https://api.github.com/repos/PaycoinFoundation/Paycoin/releases/latest | grep 'browser_' | cut -d\" -f4 | grep 'linux64.zip')
 echo "### Change to home directory"
 cd ~
 echo "### Installing Sudo"
@@ -27,9 +29,9 @@ randUser=`< /dev/urandom tr -dc A-Za-z0-9 | head -c30`
 randPass=`< /dev/urandom tr -dc A-Za-z0-9 | head -c30`
 echo "rpcuser=$randUser" >> $config
 echo "rpcpassword=$randPass" >> $config
-echo "### Downloading Paycoin Core 0.3.3.0"
-wget https://github.com/PaycoinFoundation/paycoin/releases/download/v0.3.3.0/linux64.zip
-echo "### Installing Paycoin Core 0.3.3.0"
+echo "### Downloading Paycoin Core ${version}"
+curl -# -C - -L -k -o linux64.zip $latest
+echo "### Installing Paycoin Core ${version}"
 unzip linux64.zip
 rm -f -r linux64.zip
 rm -f -r paycoin-qt

--- a/DeployPaycoinNode.sh
+++ b/DeployPaycoinNode.sh
@@ -9,7 +9,7 @@ echo "### Update Ubuntu"
 sudo apt-get update -y
 sudo apt-get upgrade -y
 sudo apt-get dist-upgrade -y
-sudo apt-get install software-properties-common python-software-properties unzip ufw -y
+sudo apt-get install software-properties-common python-software-properties unzip ufw curl wget -y
 echo "### Allow ports 22, 8998 and enable The Uncomplicated Firewall"
 sudo ufw allow 22/tcp
 sudo ufw allow 8998/tcp

--- a/DeployWebInterface.sh
+++ b/DeployWebInterface.sh
@@ -41,5 +41,17 @@ echo "### Changing to home directory"
 cd ~
 echo "### Scheduling Cron Job to run WebInterface.py every 5 minutes"
 (crontab -l ; echo "*/5 * * * * sudo python ~/WebInterface/WebInterface.py")| crontab -
-echo "### System will now reboot"
-reboot
+
+echo "### We recommend a system reboot to finish installation"
+read -p "### Would you like to reboot your system? " -n 1 -r
+echo    # Create new Line
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    # Reboot The System
+    echo "### System will reboot in 5 seconds"
+    sleep 5
+    reboot
+else
+    echo "### Please reboot your system for these changes to take effect"
+fi
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
-# PaycoinAutoNode
-Scripts to run, ideally just after setting up a new server or VPS, to automatically setup paycoind and have it start on boot together with an optional Apache web interface.
+Paycoin Auto Node
+=================
+
+What is Paycoin Auto Node?
+--------------------------
+
+Paycoin Auto Node are a handful of scripts to run, ideally just after setting up
+a new server or VPS, to automatically setup paycoind and have it start on boot
+together with an optional Apache web interface.
+
+Usage
+-----
+
+Download the scripts onto your server.
+
+Download the script to deploy the paycoind instance:
+```
+wget https://raw.githubusercontent.com/mitchellcash/PaycoinAutoNode/master/DeployPaycoinNode.sh
+```
+
+Download the script to update the paycoind instance:
+```
+wget https://raw.githubusercontent.com/mitchellcash/PaycoinAutoNode/master/UpdatePaycoinNode.sh
+```
+
+Download the script to deploy the web interface:
+```
+wget https://raw.githubusercontent.com/mitchellcash/PaycoinAutoNode/master/DeployWebInterface.sh
+```
+
+Deploy the scripts.
+
+Run the script to deploy the paycoind instance:
+```
+bash ./DeployPaycoinNode.sh
+```
+
+Run the script to update the paycoind instance:
+```
+bash ./UpdatePaycoinNode.sh
+```
+
+Run the script to deploy the web interface:
+```
+bash ./DeployWebInterface.sh
+```
+
+Example
+-------
+
+If you'd like to see an example of how the web interface looks in production see the [example web interface](http://paycoin.paynodes.io/).

--- a/README.md
+++ b/README.md
@@ -8,10 +8,19 @@ Paycoin Auto Node are a handful of scripts to run, ideally just after setting up
 a new server or VPS, to automatically setup paycoind and have it start on boot
 together with an optional Apache web interface.
 
-Usage
------
+Installation
+------------
+
+The `DeployPaycoinNode.sh` and `DeployWebInterface.sh` scripts will install all required libraries and packages needed for the usage of Paycoin Auto Node. Please only run the scripts you intend on using.
 
 Download the scripts onto your server.
+
+### Using Git
+```bash
+git clone https://github.com/mitchellcash/PaycoinAutoNode.git
+```
+
+### Using Wget
 
 Download the script to deploy the paycoind instance:
 ```
@@ -23,10 +32,15 @@ Download the script to update the paycoind instance:
 wget https://raw.githubusercontent.com/mitchellcash/PaycoinAutoNode/master/UpdatePaycoinNode.sh
 ```
 
+
 Download the script to deploy the web interface:
 ```
 wget https://raw.githubusercontent.com/mitchellcash/PaycoinAutoNode/master/DeployWebInterface.sh
 ```
+
+
+Usage
+-----
 
 Deploy the scripts.
 
@@ -39,11 +53,24 @@ Run the script to update the paycoind instance:
 ```
 bash ./UpdatePaycoinNode.sh
 ```
+Note, this script accepts the following flags
+```bash
+-h                     Show this message
+-f                     Stop and force update Paycoin
+-r                     Reboot without prompting for interaction
+-v                     Show latest available version
+```
+
+You can use the -r and -f flags in conjunction with crontab to schedule automatic reboots and updates.
+
+
 
 Run the script to deploy the web interface:
 ```
 bash ./DeployWebInterface.sh
 ```
+
+
 
 Example
 -------

--- a/UpdatePaycoinNode.sh
+++ b/UpdatePaycoinNode.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+version=$(curl -s https://api.github.com/repos/PaycoinFoundation/Paycoin/releases/latest | grep 'tag_' | cut -d\" -f4)
+latest=$(curl -s https://api.github.com/repos/PaycoinFoundation/Paycoin/releases/latest | grep 'browser_' | cut -d\" -f4 | grep 'linux64.zip')
 echo "### Changing to paycoind directory"
 cd ~
 echo "### Stopping Paycoin Server"
 ./paycoind stop
 echo "### Changing to home directory"
 cd ~
-echo "### Downloading Paycoin Core 0.3.3.0"
-wget https://github.com/PaycoinFoundation/paycoin/releases/download/v0.3.3.0/linux64.zip
-echo "### Installing Paycoin Core 0.3.3.0"
+echo "### Downloading Paycoin Core ${version}"
+echo $latest
+#curl -O $latest
+curl -# -C - -L -k -o linux64.zip $latest
+echo "### Installing Paycoin Core ${version}"
 rm -f -r paycoind
 unzip linux64.zip
 rm -f -r linux64.zip

--- a/UpdatePaycoinNode.sh
+++ b/UpdatePaycoinNode.sh
@@ -1,14 +1,30 @@
 #!/bin/bash
-githubapi=$(curl -s https://api.github.com/rate_limit)
-
-version=$(curl -s https://api.github.com/repos/PaycoinFoundation/Paycoin/releases/latest | grep 'tag_' | cut -d\" -f4)
+version=$(curl -s https://api.github.com/repos/PaycoinFoundation/Paycoin/releases/latest | grep 'tag_' | cut -d\" -f4 | sed 's/\v//g')
 latest=$(curl -s https://api.github.com/repos/PaycoinFoundation/Paycoin/releases/latest | grep 'browser_' | cut -d\" -f4 | grep 'linux64.zip')
 echo "### Changing to paycoind directory"
 cd ~
-echo "### Stopping Paycoin Server"
-./paycoind stop
-echo "### Changing to home directory"
-cd ~
+
+xpy_version=$(./paycoind getinfo 2> /dev/null | grep '"version"' | cut -d\" -f4 | sed 's/\v//g' >/dev/null)
+# Check we are running the same version; otherwise; update
+
+if [[ "${xpy_version}" == "" ]]
+then
+    echo "### Paycoin Server Not Running, Unable to Check Version"
+    echo "### The latest is available version is v${version}"
+else 
+    if [[ "${version}" == "${xpy_version}" ]]
+    then
+        echo "### You are already running the latest version: v${version}"
+        echo "### Exiting updater script."
+        exit 1
+    else
+        echo "### You are running Paycoin Core v#{xpy_version}"
+        echo "### The latest is available version is v${version}"
+        echo "### Stopping Paycoin Server"
+        ./paycoind stop
+    fi
+fi
+
 echo "### Downloading Paycoin Core ${version}"
 curl -# -C - -L -k -o linux64.zip $latest
 echo "### Installing Paycoin Core ${version}"
@@ -16,5 +32,17 @@ rm -f -r paycoind
 unzip linux64.zip
 rm -f -r linux64.zip
 rm -f -r paycoin-qt
-echo "### System will now reboot"
-reboot
+
+echo "### We recommend a system reboot to finish installation"
+read -p "### Would you like to reboot your system? " -n 1 -r
+echo    # Create new Line
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    # Reboot The System
+    echo "### System will reboot in 5 seconds"
+    sleep 5
+    reboot
+else
+    echo "### Please reboot your system for these changes to take effect"
+fi
+

--- a/UpdatePaycoinNode.sh
+++ b/UpdatePaycoinNode.sh
@@ -1,26 +1,66 @@
 #!/bin/bash
+set -e
+
 version=$(curl -s https://api.github.com/repos/PaycoinFoundation/Paycoin/releases/latest | grep 'tag_' | cut -d\" -f4 | sed 's/\v//g')
 latest=$(curl -s https://api.github.com/repos/PaycoinFoundation/Paycoin/releases/latest | grep 'browser_' | cut -d\" -f4 | grep 'linux64.zip')
+
+while getopts ":frhv" opt; do
+  case $opt in
+    f)
+      FORCE=1
+      ;;
+    r)
+      REBOOT=1
+      ;;
+    h)
+      echo "-f                     Stop and force update Paycoin"
+      echo "-r                     Reboot without prompting for interaction"
+      echo "-v                     Show latest available version"
+      exit 0
+      ;;
+    v)
+      echo "### The latest is available version is v${version}"
+      exit 0
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 2
+      ;;
+  esac
+done
+
 echo "### Changing to paycoind directory"
 cd ~
+
 xpy_version=$(./paycoind getinfo | grep '"version"' | cut -d\" -f4 | sed 's/\v//g' )
 # Check we are running the same version; otherwise; update
 
-if [[ "${xpy_version}" == "" ]]
+if [ ! -z $FORCE ]
 then
-    echo "### Paycoin server not running, Unable to check version"
-    echo "### The latest is available version is v${version}"
-else 
-    if [[ "${version}" == "${xpy_version}" ]]
+    echo "### The latest available version is v${version}"
+    echo "### Stopping Paycoin server"
+    ./paycoind stop
+else
+    if [[ "${xpy_version}" == "" ]]
     then
-        echo "### You are already running the latest version: v${version}"
-        echo "### Exiting updater script."
-        exit 1
-    else
-        echo "### You are running Paycoin Core v#{xpy_version}"
-        echo "### The latest available version is v${version}"
-        echo "### Stopping Paycoin server"
-        ./paycoind stop
+        echo "### Paycoin server not running, Unable to check version"
+        echo "### The latest is available version is v${version}"
+    else 
+        if [[ "${version}" == "${xpy_version}" ]]
+        then
+            echo "### You are already running the latest version: v${version}"
+            echo "### Exiting updater script."
+            exit 1
+        else
+            echo "### You are running Paycoin Core v#{xpy_version}"
+            echo "### The latest available version is v${version}"
+            echo "### Stopping Paycoin server"
+            ./paycoind stop
+        fi
     fi
 fi
 
@@ -33,15 +73,22 @@ rm -f -r linux64.zip
 rm -f -r paycoin-qt
 
 echo "### We recommend a system reboot to finish installation"
-read -p "### Would you like to reboot your system? " -n 1 -r
-echo    # Create new Line
-if [[ $REPLY =~ ^[Yy]$ ]]
+if [ ! -z $REBOOT ]
 then
     # Reboot The System
     echo "### System will reboot in 5 seconds"
     sleep 5
     reboot
 else
-    echo "### Please reboot your system for these changes to take effect"
+    read -p "### Would you like to reboot your system? " -n 1 -r
+    echo    # Create new Line
+    if [[ $REPLY =~ ^[Yy]$ ]]
+    then
+        # Reboot The System
+        echo "### System will reboot in 5 seconds"
+        sleep 5
+        reboot
+    else
+        echo "### Please reboot your system for these changes to take effect"
+    fi
 fi
-

--- a/UpdatePaycoinNode.sh
+++ b/UpdatePaycoinNode.sh
@@ -18,7 +18,7 @@ else
         exit 1
     else
         echo "### You are running Paycoin Core v#{xpy_version}"
-        echo "### The latest is available version is v${version}"
+        echo "### The latest available version is v${version}"
         echo "### Stopping Paycoin server"
         ./paycoind stop
     fi

--- a/UpdatePaycoinNode.sh
+++ b/UpdatePaycoinNode.sh
@@ -3,13 +3,12 @@ version=$(curl -s https://api.github.com/repos/PaycoinFoundation/Paycoin/release
 latest=$(curl -s https://api.github.com/repos/PaycoinFoundation/Paycoin/releases/latest | grep 'browser_' | cut -d\" -f4 | grep 'linux64.zip')
 echo "### Changing to paycoind directory"
 cd ~
-
-xpy_version=$(./paycoind getinfo 2> /dev/null | grep '"version"' | cut -d\" -f4 | sed 's/\v//g' >/dev/null)
+xpy_version=$(./paycoind getinfo | grep '"version"' | cut -d\" -f4 | sed 's/\v//g' )
 # Check we are running the same version; otherwise; update
 
 if [[ "${xpy_version}" == "" ]]
 then
-    echo "### Paycoin Server Not Running, Unable to Check Version"
+    echo "### Paycoin server not running, Unable to check version"
     echo "### The latest is available version is v${version}"
 else 
     if [[ "${version}" == "${xpy_version}" ]]
@@ -20,7 +19,7 @@ else
     else
         echo "### You are running Paycoin Core v#{xpy_version}"
         echo "### The latest is available version is v${version}"
-        echo "### Stopping Paycoin Server"
+        echo "### Stopping Paycoin server"
         ./paycoind stop
     fi
 fi

--- a/UpdatePaycoinNode.sh
+++ b/UpdatePaycoinNode.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+githubapi=$(curl -s https://api.github.com/rate_limit)
+
 version=$(curl -s https://api.github.com/repos/PaycoinFoundation/Paycoin/releases/latest | grep 'tag_' | cut -d\" -f4)
 latest=$(curl -s https://api.github.com/repos/PaycoinFoundation/Paycoin/releases/latest | grep 'browser_' | cut -d\" -f4 | grep 'linux64.zip')
 echo "### Changing to paycoind directory"
@@ -8,8 +10,6 @@ echo "### Stopping Paycoin Server"
 echo "### Changing to home directory"
 cd ~
 echo "### Downloading Paycoin Core ${version}"
-echo $latest
-#curl -O $latest
 curl -# -C - -L -k -o linux64.zip $latest
 echo "### Installing Paycoin Core ${version}"
 rm -f -r paycoind

--- a/UpdatePaycoinNode.sh
+++ b/UpdatePaycoinNode.sh
@@ -13,6 +13,7 @@ while getopts ":frhv" opt; do
       REBOOT=1
       ;;
     h)
+      echo "-h                     Show this message"
       echo "-f                     Stop and force update Paycoin"
       echo "-r                     Reboot without prompting for interaction"
       echo "-v                     Show latest available version"


### PR DESCRIPTION
The scripts will now download the latest full release from GitHub, Regardless of Version.

This negates the need for manual updating of version numbers within all scripts.

Also switch to Curl for downloading the file since it looks nicer.

Please note; due to the fact that this uses the GitHub API. We have a limited amount of requests that we can make.
I will be implementing some logic to check if this is the case and notify the user.
Alternatively; we can poll GitHub for the rate to check we are able to submit a core request before polling for the version. This will avoid blocking on the server/client side
