### PR TITLE
Include --upgrade pip as part of deploy process

### DIFF
--- a/DeployWebInterface.sh
+++ b/DeployWebInterface.sh
@@ -10,6 +10,8 @@ sudo apt-get update -y
 sudo apt-get upgrade -y
 sudo apt-get dist-upgrade -y
 sudo apt-get install python-pip apache2 -y
+echo "### Updating pip"
+sudo pip install --upgrade pip
 echo "### Allow ports 80, 8999 and enable The Uncomplicated Firewall"
 sudo ufw allow 80/tcp
 sudo ufw allow 8999/tcp
@@ -54,4 +56,3 @@ then
 else
     echo "### Please reboot your system for these changes to take effect"
 fi
-


### PR DESCRIPTION
On Linux, pip will generally be available for the system install of python using the system package manager, although often the latest version will be unavailable.

Creative liberty taken by myself with the commit message. I just guessed why the commit might have wanted to be made.

Pulled from #8. Original author @sk00t3r. 
